### PR TITLE
PR: Make project pip installable and add @import support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+
+install:
+  - "pip install -r requirements.txt"
+
+script:
+  - nosetests -v -s

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,6 +1,7 @@
+* Yann Lanthony <https://github.com/yann-lty> (Original qtsass author).
+
 The Spyder Project Contributors are composed of:
 
-* Yann Lanthony <https://github.com/yann-lty> (Original qtsass author).
 * Dan Bradham <danielbradham@gmail.com> (Current maintainer).
 * All other developers who have contributed to this repository
   and/or the original documentation on the main spyder-ide/spyder repository.

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,0 +1,9 @@
+* Yann Lanthony <N/A> (Original qtsass author).
+
+The Spyder Project Contributors are composed of:
+
+* Pierre Raybaut <pierre.raybaut@gmail.com> (Original Spyder author).
+* Carlos Cordoba <ccordoba12@gmail.com> (Current maintainer).
+* Dan Bradham <danielbradham@gmail.com> (Current maintainer).
+* All other developers who have contributed to this repository
+  and/or the original documentation on the main spyder-ide/spyder repository.

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,9 +1,6 @@
-* Yann Lanthony <N/A> (Original qtsass author).
-
 The Spyder Project Contributors are composed of:
 
-* Pierre Raybaut <pierre.raybaut@gmail.com> (Original Spyder author).
-* Carlos Cordoba <ccordoba12@gmail.com> (Current maintainer).
+* Yann Lanthony <N/A> (Original qtsass author).
 * Dan Bradham <danielbradham@gmail.com> (Current maintainer).
 * All other developers who have contributed to this repository
   and/or the original documentation on the main spyder-ide/spyder repository.

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,6 +1,6 @@
 The Spyder Project Contributors are composed of:
 
-* Yann Lanthony <N/A> (Original qtsass author).
+* Yann Lanthony <https://github.com/yann-lty> (Original qtsass author).
 * Dan Bradham <danielbradham@gmail.com> (Current maintainer).
 * All other developers who have contributed to this repository
   and/or the original documentation on the main spyder-ide/spyder repository.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) The Spyder Development Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) The Spyder Development Team
+Copyright (c) 2015 Yann Lanthony
+Copyright (c) 2017-2018 Spyder Project Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -67,7 +67,11 @@ The qlineargradient function also has a non-valid CSS syntax.
 ```
 qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0.1 blue, stop: 0.8 green)
 ```
-Using QtSass, syntax changes a little bit:
+To support qlineargradient QtSASS provides a preprocessor and a SASS implementation of the qlineargradient function. The above QSS syntax will be replaced with the following:
+```
+qlineargradient(0, 0, 0, 1, (0.1 blue, 0.8 green))
+```
+You may also use this syntax directly in your QtSASS.
 ```
 qlineargradient(0, 0, 0, 1, (0.1 blue, 0.8 green))
 # the stops parameter is a list, so you can also use variables:

--- a/examples/dummy.scss
+++ b/examples/dummy.scss
@@ -8,11 +8,22 @@ QComboBox:!editable:on, QComboBox::drop-down:editable:on
     color: blue;
 }
 
+// standard qss qlineargradient syntax works
+QListView::item:selected{
+    background-color: qlineargradient(
+        x1: 0,
+        y1: 0,
+        x2: 0,
+        y2:1,
+        stop: 0.2 #3f3f3f,
+        stop: 0.8 red
+    );
+}
+
+// You may also use QtSASS syntax directly
 QTreeView::item:selected{
     $start: 0.2;
     $stops: $start #3f3f3f, $start + 0.6 red;
-    // qlineargradient syntax changes a little bit
-    // classic Qt: qlineargradient(x1: 0, y1: 0, x2: 0, y2:1, stop: 0.2 #3f3f3f, stop: 0.8 red)
     background-color: qlineargradient(0, 0, 0, 1, $stops);
     color: rgba(255, 10, 10, 0.5);
 }

--- a/qtsass/__init__.py
+++ b/qtsass/__init__.py
@@ -1,5 +1,4 @@
-__title__ = 'qtsass'
-__description__ = 'Compile SCSS files to valid Qt stylesheets.'
-__author__ = 'yann.lanthony'
-__version__ = '0.1.0'
-__url__ = 'https://github.com/spyder-ide/qtsass'
+# -*- coding: utf-8 -*-
+
+VERSION_INFO = (0, 1, 0)
+__version__ = '.'.join(map(str, VERSION_INFO))

--- a/qtsass/__init__.py
+++ b/qtsass/__init__.py
@@ -1,1 +1,5 @@
+__title__ = 'qtsass'
+__description__ = 'Compile SCSS files to valid Qt stylesheets.'
 __author__ = 'yann.lanthony'
+__version__ = '0.1.0'
+__url__ = 'https://github.com/spyder-ide/qtsass'

--- a/qtsass/__init__.py
+++ b/qtsass/__init__.py
@@ -1,4 +1,11 @@
 # -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2015 Yann Lanthony
+# Copyright (c) 2017-2018 Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (See LICENSE.txt for details)
+# -----------------------------------------------------------------------------
 
 VERSION_INFO = (0, 1, 0)
 __version__ = '.'.join(map(str, VERSION_INFO))

--- a/qtsass/qtsass.py
+++ b/qtsass/qtsass.py
@@ -52,8 +52,10 @@ conformers = [c() for c in Conformer.__subclasses__() if c is not Conformer]
 
 def css_conform(input_str):
     """
-    Conform qss to valid scss. Runs the to_css method of all Conformer
-    subclasses on the input_str. Conformers are run in order of definition.
+    Conform qss to valid scss.
+
+    Runs the to_css method of all Conformer subclasses on the input_str.
+    Conformers are run in order of definition.
 
     :param input_str: QSS string
     :returns: Valid SCSS string
@@ -68,8 +70,10 @@ def css_conform(input_str):
 
 def qt_conform(input_str):
     """
-    Conform css to valid qss. Runs the to_qss method of all Conformer
-    subclasses on the input_str. Conformers are run in reverse order.
+    Conform css to valid qss.
+
+    Runs the to_qss method of all Conformer subclasses on the input_str.
+    Conformers are run in reverse order.
 
     :param input_str: CSS string
     :returns: Valid QSS string
@@ -130,6 +134,7 @@ def rgba(r, g, b, a):
 def rgba_from_color(color):
     """
     Conform rgba
+
     :type color: sass.SassColor
     """
     return rgba(color.r, color.g, color.b, color.a)
@@ -137,6 +142,8 @@ def rgba_from_color(color):
 
 def qlineargradient(x1, y1, x2, y2, stops):
     """
+    Implementation of qss qlineargradient function for scss.
+
     :type x1: sass.SassNumber
     :type y1: sass.SassNumber
     :type x2: sass.SassNumber

--- a/qtsass/qtsass.py
+++ b/qtsass/qtsass.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function
-import sass
 import argparse
 import logging
 import os
 import re
 import time
+import sass
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 

--- a/qtsass/qtsass.py
+++ b/qtsass/qtsass.py
@@ -16,9 +16,9 @@ import logging
 import os
 import re
 import time
-import sass
 
 # Third party imports
+import sass
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 

--- a/qtsass/qtsass.py
+++ b/qtsass/qtsass.py
@@ -88,8 +88,13 @@ class QLinearGradientConformer(Conformer):
         conformed = qss
 
         for coords, stops in self.qss_pattern.findall(qss):
+
             new_coords = self._conform_group_to_css(coords)
             conformed = conformed.replace(coords, new_coords, 1)
+
+            if not stops:
+                continue
+
             new_stops = ", ({})".format(self._conform_group_to_css(stops))
             conformed = conformed.replace(stops, new_stops, 1)
 

--- a/qtsass/qtsass.py
+++ b/qtsass/qtsass.py
@@ -53,8 +53,8 @@ class QLinearGradientConformer(Conformer):
 
     qss_pattern = re.compile(
         "qlineargradient\("
-        "((?:(?:\s+)?(?:x1|y1|x2|y2):(?:\s+)?\d+,?)+)"  # coords group
-        "((?:(?:\s+)?stop:.*,?)+(?:\s+)?)?"  # stops group
+        "((?:(?:\s+)?(?:x1|y1|x2|y2):(?:\s+)?[0-9A-Za-z$_-]+,?)+)"  # coords
+        "((?:(?:\s+)?stop:.*,?)+(?:\s+)?)?"  # stops
         "\)",
         re.MULTILINE
     )

--- a/qtsass/qtsass.py
+++ b/qtsass/qtsass.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function
 import sass
 import argparse
 import logging

--- a/qtsass/qtsass.py
+++ b/qtsass/qtsass.py
@@ -156,7 +156,7 @@ def qlineargradient(x1, y1, x2, y2, stops):
         pos, color = stop[0]
         stops_str += " stop: {} {}".format(pos.value, rgba_from_color(color))
 
-    return "qlineargradient(x1:{}, y1:{}, x2:{}, y2:{} {})".format(
+    return "qlineargradient(x1:{}, y1:{}, x2:{}, y2:{},{})".format(
         x1.value,
         y1.value,
         x2.value,

--- a/qtsass/qtsass.py
+++ b/qtsass/qtsass.py
@@ -52,10 +52,10 @@ class QLinearGradientConformer(Conformer):
     """Conform QSS qlineargradient function."""
 
     qss_pattern = re.compile(
-        "qlineargradient\("
-        "((?:(?:\s+)?(?:x1|y1|x2|y2):(?:\s+)?[0-9A-Za-z$_-]+,?)+)"  # coords
-        "((?:(?:\s+)?stop:.*,?)+(?:\s+)?)?"  # stops
-        "\)",
+        'qlineargradient\('
+        '((?:(?:\s+)?(?:x1|y1|x2|y2):(?:\s+)?[0-9A-Za-z$_-]+,?)+)'  # coords
+        '((?:(?:\s+)?stop:.*,?)+(?:\s+)?)?'  # stops
+        '\)',
         re.MULTILINE
     )
 
@@ -68,11 +68,11 @@ class QLinearGradientConformer(Conformer):
         'stop: 0 red, stop: 1 blue' => '0 red, 1 blue'
         """
         new_group = []
-        for part in group.strip().split(","):
+        for part in group.strip().split(','):
             if part:
-                _, value = part.split(":")
+                _, value = part.split(':')
                 new_group.append(value.strip())
-        return ", ".join(new_group)
+        return ', '.join(new_group)
 
     def to_css(self, qss):
         """
@@ -95,7 +95,7 @@ class QLinearGradientConformer(Conformer):
             if not stops:
                 continue
 
-            new_stops = ", ({})".format(self._conform_group_to_css(stops))
+            new_stops = ', ({})'.format(self._conform_group_to_css(stops))
             conformed = conformed.replace(stops, new_stops, 1)
 
         return conformed
@@ -178,7 +178,7 @@ def qss_importer(where):
 
 
 def rgba(r, g, b, a):
-    result = "rgba({}, {}, {}, {}%)"
+    result = 'rgba({}, {}, {}, {}%)'
     if isinstance(r, sass.SassNumber):
         return result.format(
             int(r.value),
@@ -210,24 +210,24 @@ def qlineargradient(x1, y1, x2, y2, stops):
     :type stops: sass.SassList
     :return:
     """
-    stops_str = ""
+    stops_str = ''
     for stop in stops[0]:
         pos, color = stop[0]
-        stops_str += " stop: {} {}".format(pos.value, rgba_from_color(color))
+        stops_str += ' stop: {} {}'.format(pos.value, rgba_from_color(color))
 
-    return "qlineargradient(x1: {}, y1: {}, x2: {}, y2: {},{})".format(
+    return 'qlineargradient(x1: {}, y1: {}, x2: {}, y2: {},{})'.format(
         x1.value,
         y1.value,
         x2.value,
         y2.value,
-        stops_str.rstrip(",")
+        stops_str.rstrip(',')
     )
 
 
 def compile_to_css(input_file):
-    logger.debug("Compiling {}...".format(input_file))
+    logger.debug('Compiling {}...'.format(input_file))
 
-    with open(input_file, "r") as f:
+    with open(input_file, 'r') as f:
         input_str = f.read()
 
     try:
@@ -244,7 +244,7 @@ def compile_to_css(input_file):
             )
         )
     except sass.CompileError as e:
-        logging.error("Failed to compile {}:\n{}".format(input_file, e))
+        logging.error('Failed to compile {}:\n{}'.format(input_file, e))
     return ""
 
 
@@ -253,7 +253,7 @@ def compile_to_css_and_save(input_file, dest_file):
     if dest_file:
         with open(dest_file, 'w') as css_file:
             css_file.write(stylesheet)
-            logger.info("Created CSS file {}".format(dest_file))
+            logger.info('Created CSS file {}'.format(dest_file))
     else:
         print(stylesheet)
 
@@ -297,21 +297,21 @@ class SourceModificationEventHandler(FileSystemEventHandler):
 
 def main():
     parser = argparse.ArgumentParser(
-        prog="QtSASS",
-        description="Compile a Qt compliant CSS file from a SASS stylesheet.",
+        prog='QtSASS',
+        description='Compile a Qt compliant CSS file from a SASS stylesheet.',
     )
-    parser.add_argument('input', type=str, help="The SASS stylesheet file.")
+    parser.add_argument('input', type=str, help='The SASS stylesheet file.')
     parser.add_argument(
         '-o',
         '--output',
         type=str,
-        help="The path of the generated Qt compliant CSS file."
+        help='The path of the generated Qt compliant CSS file.'
     )
     parser.add_argument(
         '-w',
         '--watch',
         action='store_true',
-        help="If set, recompile when the source file changes."
+        help='If set, recompile when the source file changes.'
     )
 
     args = parser.parse_args()
@@ -324,7 +324,7 @@ def main():
             args.output,
             watched_dir
         )
-        logging.info("qtsass is watching {}...".format(args.input))
+        logging.info('qtsass is watching {}...'.format(args.input))
         observer = Observer()
         observer.schedule(event_handler, watched_dir, recursive=False)
         observer.start()

--- a/qtsass/qtsass.py
+++ b/qtsass/qtsass.py
@@ -1,5 +1,15 @@
-#!/usr/bin/env
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2015 Yann Lanthony
+# Copyright (c) 2017-2018 Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (See LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+'''qtsass - Compile SCSS files to valid Qt stylesheets.'''
+
+# Standard library imports
 from __future__ import absolute_import, print_function
 import argparse
 import logging
@@ -7,6 +17,8 @@ import os
 import re
 import time
 import sass
+
+# Third party imports
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 

--- a/qtsass/qtsass.py
+++ b/qtsass/qtsass.py
@@ -9,32 +9,40 @@ import time
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
+# py2 has no FileNotFoundError
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
 class Conformer(object):
-    '''Base class for all Text transformations'''
+    """Base class for all text transformations."""
 
     def to_css(self, qss):
-        '''Transform some qss to valid scss'''
+        """Transform some qss to valid scss."""
+
         return NotImplemented
 
     def to_qss(self, css):
-        '''Transform some css to valid qss'''
+        """Transform some css to valid qss."""
+
         return NotImplemented
 
 
 class NotConformer(Conformer):
-    '''Handle QSS "!" in selectors'''
+    """Handle QSS "!" in selectors."""
 
     def to_css(self, qss):
-        '''Replaces "!" not in selectors with "_qnot_"'''
+        """Replaces "!" in selectors with "_qnot_"."""
 
         return qss.replace(':!', ':_qnot_')
 
     def to_qss(self, css):
-        '''Replaces "_qnot_" in selectors with "!"'''
+        """Replaces "_qnot_" in selectors with "!"."""
 
         return css.replace(':_qnot_', ':!')
 
@@ -43,14 +51,13 @@ conformers = [c() for c in Conformer.__subclasses__() if c is not Conformer]
 
 
 def css_conform(input_str):
-    '''Conform qss to valid scss.
-
-    Runs the to_css method of all Conformer subclasses on the input_str.
-    Conformers are run in order of definition.
+    """
+    Conform qss to valid scss. Runs the to_css method of all Conformer
+    subclasses on the input_str. Conformers are run in order of definition.
 
     :param input_str: QSS string
     :returns: Valid SCSS string
-    '''
+    """
 
     conformed = input_str
     for conformer in conformers:
@@ -60,14 +67,13 @@ def css_conform(input_str):
 
 
 def qt_conform(input_str):
-    '''Conform css to valid qss.
-
-    Runs the to_qss method of all Conformer subclasses on the input_str.
-    Conformers are run in reverse order.
+    """
+    Conform css to valid qss. Runs the to_qss method of all Conformer
+    subclasses on the input_str. Conformers are run in reverse order.
 
     :param input_str: CSS string
     :returns: Valid QSS string
-    '''
+    """
 
     conformed = input_str
     for conformer in conformers[::-1]:
@@ -76,7 +82,12 @@ def qt_conform(input_str):
 
 
 def qss_importer(where):
-    '''Conform imported qss files to valid scss.'''
+    """
+    Returns a function which conforms imported qss files to valid scss to be
+    used as an importer for sass.compile.
+
+    :param where: Directory containing scss, css, and sass files
+    """
 
     def find_file(import_file):
 
@@ -182,6 +193,7 @@ def compile_to_css_and_save(input_file, dest_file):
 
 
 class SourceModificationEventHandler(FileSystemEventHandler):
+
     def __init__(self, input_file, dest_file, watched_dir):
         super(SourceModificationEventHandler, self).__init__()
         self._input_file = input_file
@@ -202,8 +214,8 @@ class SourceModificationEventHandler(FileSystemEventHandler):
 
     def on_modified(self, event):
         # On Mac, event will always be a directory.
-        # On Windows, only recompile if event's file has
-        #             the same extension as the input file
+        # On Windows, only recompile if event's file
+        # has the same extension as the input file
         we_should_recompile = (
             event.is_directory and
             os.path.samefile(event.src_path, self._watched_dir) or
@@ -233,10 +245,7 @@ def main():
         '-w',
         '--watch',
         action='store_true',
-        help=(
-            "Whether to watch source file "
-            "and automatically recompile on file change."
-        )
+        help="If set, recompile when the source file changes."
     )
 
     args = parser.parse_args()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+libsass
+watchdog

--- a/setup.py
+++ b/setup.py
@@ -1,32 +1,71 @@
-from setuptools import setup, find_packages
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2015 Yann Lanthony
+# Copyright (c) 2017-2018 Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (See LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+"""Setup script for qtsass."""
+
+# Standard library imports
+import ast
+import os
 from io import open
-import qtsass
+
+# Third party imports
+from setuptools import find_packages, setup
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+
+def get_version(module='qtsass'):
+    """Get version."""
+    with open(os.path.join(HERE, module, '__init__.py'), 'r') as f:
+        data = f.read()
+    lines = data.split('\n')
+    for line in lines:
+        if line.startswith('VERSION_INFO'):
+            version_tuple = ast.literal_eval(line.split('=')[-1].strip())
+            version = '.'.join(map(str, version_tuple))
+            break
+    return version
+
+
+def get_description():
+    """Get long description."""
+    with open(os.path.join(HERE, 'README.md'), 'r', encoding='utf-8') as f:
+        data = f.read()
+    return data
 
 
 setup(
-    name=qtsass.__title__,
-    version=qtsass.__version__,
-    description=qtsass.__description__,
-    long_description=open("README.md", "r", encoding="utf-8").read(),
-    author=qtsass.__author__,
-    author_email="N/A",
-    url=qtsass.__url__,
-    license="N/A",
+    name='qtsass',
+    version=get_version(),
+    description='Compile SCSS files to valid Qt stylesheets.',
+    long_description=get_description(),
+    author='Yann Lanthony',
+    author_email='N/A',
+    maintainer='Dan Bradham',
+    maintainer_email='danielbradham@gmail.com',
+    url='https://github.com/spyder-ide/qtsass',
+    license='N/A',
     packages=find_packages(),
     entry_points={
-        "console_scripts": [
-            "qtsass = qtsass.qtsass:main"
+        'console_scripts': [
+            'qtsass = qtsass.qtsass:main'
         ]
     },
     classifiers=(
-        "Development Status :: 3 - Alpha",
-        "Intended Audience :: Developers",
-        "Natural Language :: English",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
-        "Topic :: Software Development :: Libraries :: Python Modules",
+        'Topic :: Software Development :: Libraries :: Python Modules',
     ),
     install_requires=[
         'libsass',

--- a/setup.py
+++ b/setup.py
@@ -46,11 +46,11 @@ setup(
     description='Compile SCSS files to valid Qt stylesheets.',
     long_description=get_description(),
     author='Yann Lanthony',
-    author_email='N/A',
+    author_email='https://github.com/yann-lty',
     maintainer='Dan Bradham',
     maintainer_email='danielbradham@gmail.com',
     url='https://github.com/spyder-ide/qtsass',
-    license='N/A',
+    license='MIT',
     packages=find_packages(),
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,34 @@
-from cx_Freeze import setup, Executable
+from setuptools import setup, find_packages
+import qtsass
 
-build_exe_options = {
-    'include_msvcr': True,
-    'bin_includes': ['msvcp120.dll'],  # Force msvcp120 to be included (libsass dependency, not copied by include_mscvr)
-    'optimize': 2
-}
 
 setup(
-    name="qtsass",
-    description="Compile a SCSS file to a valid Qt CSS.",
-    executables=[Executable("qtsass/qtsass.py")],
-    options={'build_exe': build_exe_options},
-    requires=['libsass', 'cx_Freeze', 'watchdog'],
+    name=qtsass.__title__,
+    version='0.1.0',
+    description=qtsass.__description__,
+    long_description=open('README.md', 'r').read(),
+    author=qtsass.__author__,
+    author_email='N/A',
+    url=qtsass.__url__,
+    license='N/A',
+    packages=find_packages(),
+    entry_points={
+        'console_scripts': [
+            'qtsass = qtsass.qtsass:main'
+        ]
+    },
+    classifiers=(
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ),
+    install_requires=[
+        'libsass',
+        'watchdog'
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,21 @@
 from setuptools import setup, find_packages
+from io import open
 import qtsass
 
 
 setup(
     name=qtsass.__title__,
-    version='0.1.0',
+    version=qtsass.__version__,
     description=qtsass.__description__,
-    long_description=open('README.md', 'r').read(),
+    long_description=open("README.md", "r", encoding="utf-8").read(),
     author=qtsass.__author__,
-    author_email='N/A',
+    author_email="N/A",
     url=qtsass.__url__,
-    license='N/A',
+    license="N/A",
     packages=find_packages(),
     entry_points={
-        'console_scripts': [
-            'qtsass = qtsass.qtsass:main'
+        "console_scripts": [
+            "qtsass = qtsass.qtsass:main"
         ]
     },
     classifiers=(

--- a/test_qtsass.py
+++ b/test_qtsass.py
@@ -32,9 +32,16 @@ class TestNotConformer(unittest.TestCase):
 
 class TestQLinearGradientConformer(unittest.TestCase):
 
-    css_str = "qlineargradient(0, 0, 0, 0, (0 red, 1 blue))"
+    css_vars_str = "qlineargradient($x1, $x2, $y1, $y2, (0 $red, 1 $blue))"
+    qss_vars_str = (
+        "qlineargradient(x1:$x1, x2:$x2, y1:$y1, y2:$y2"
+        "stop: 0 $red, stop: 1 $blue)"
+    )
+
     css_nostops_str = "qlineargradient(0, 0, 0, 0)"
     qss_nostops_str = "qlineargradient(x1: 0, y1: 0, x2: 0, y2: 0)"
+
+    css_str = "qlineargradient(0, 0, 0, 0, (0 red, 1 blue))"
     qss_singleline_str = (
         "qlineargradient(x1: 0, y1: 0, x2: 0, y2: 0, "
         "stop: 0 red, stop: 1 blue)"
@@ -84,6 +91,12 @@ class TestQLinearGradientConformer(unittest.TestCase):
 
         c = QLinearGradientConformer()
         self.assertEqual(c.to_css(self.qss_nostops_str), self.css_nostops_str)
+
+    def test_conform_vars_str(self):
+        """QLinearGradientConformer qss with vars to css"""
+
+        c = QLinearGradientConformer()
+        self.assertEqual(c.to_css(self.qss_vars_str), self.css_vars_str)
 
 
 if __name__ == '__main__':

--- a/test_qtsass.py
+++ b/test_qtsass.py
@@ -33,6 +33,8 @@ class TestNotConformer(unittest.TestCase):
 class TestQLinearGradientConformer(unittest.TestCase):
 
     css_str = "qlineargradient(0, 0, 0, 0, (0 red, 1 blue))"
+    css_nostops_str = "qlineargradient(0, 0, 0, 0)"
+    qss_nostops_str = "qlineargradient(x1: 0, y1: 0, x2: 0, y2: 0)"
     qss_singleline_str = (
         "qlineargradient(x1: 0, y1: 0, x2: 0, y2: 0, "
         "stop: 0 red, stop: 1 blue)"
@@ -76,6 +78,12 @@ class TestQLinearGradientConformer(unittest.TestCase):
 
         c = QLinearGradientConformer()
         self.assertEqual(c.to_css(self.qss_weird_whitespace_str), self.css_str)
+
+    def test_conform_nostops_str(self):
+        """QLinearGradientConformer qss with no stops to css"""
+
+        c = QLinearGradientConformer()
+        self.assertEqual(c.to_css(self.qss_nostops_str), self.css_nostops_str)
 
 
 if __name__ == '__main__':

--- a/test_qtsass.py
+++ b/test_qtsass.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+import unittest
+from textwrap import dedent
+from qtsass.qtsass import NotConformer, QLinearGradientConformer
+
+
+class TestNotConformer(unittest.TestCase):
+
+    qss_str = "QAbstractItemView::item:!active"
+    css_str = "QAbstractItemView::item:_qnot_active"
+
+    def test_conform_to_css(self):
+        """NotConformer qss to css"""
+
+        c = NotConformer()
+        self.assertEqual(c.to_css(self.qss_str), self.css_str)
+
+    def test_conform_to_qss(self):
+        """NotConformer css to qss"""
+
+        c = NotConformer()
+        self.assertEqual(c.to_qss(self.css_str), self.qss_str)
+
+    def test_round_trip(self):
+        """NotConformer roundtrip"""
+
+        c = NotConformer()
+        conformed_css = c.to_css(self.qss_str)
+        self.assertEqual(c.to_qss(conformed_css), self.qss_str)
+
+
+class TestQLinearGradientConformer(unittest.TestCase):
+
+    css_str = "qlineargradient(0, 0, 0, 0, (0 red, 1 blue))"
+    qss_singleline_str = (
+        "qlineargradient(x1: 0, y1: 0, x2: 0, y2: 0, "
+        "stop: 0 red, stop: 1 blue)"
+    )
+    qss_multiline_str = dedent("""
+    qlineargradient(
+        x1: 0,
+        y1: 0,
+        x2: 0,
+        y2: 0,
+        stop: 0 red,
+        stop: 1 blue
+    )
+    """).strip()
+    qss_weird_whitespace_str = (
+        "qlineargradient( x1: 0, y1:0, x2: 0, y2:0, "
+        "   stop:0 red, stop: 1 blue )"
+    )
+
+    def test_does_not_affect_css_form(self):
+        """QLinearGradientConformer does not affect css qlineargradient func"""
+
+        c = QLinearGradientConformer()
+        self.assertEqual(c.to_css(self.css_str), self.css_str)
+        self.assertEqual(c.to_qss(self.css_str), self.css_str)
+
+    def test_conform_singleline_str(self):
+        """QLinearGradientConformer singleline qss to css"""
+
+        c = QLinearGradientConformer()
+        self.assertEqual(c.to_css(self.qss_singleline_str), self.css_str)
+
+    def test_conform_multiline_str(self):
+        """QLinearGradientConformer multiline qss to css"""
+
+        c = QLinearGradientConformer()
+        self.assertEqual(c.to_css(self.qss_multiline_str), self.css_str)
+
+    def test_conform_weird_whitespace_str(self):
+        """QLinearGradientConformer weird whitespace qss to css"""
+
+        c = QLinearGradientConformer()
+        self.assertEqual(c.to_css(self.qss_weird_whitespace_str), self.css_str)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_qtsass.py
+++ b/test_qtsass.py
@@ -1,7 +1,20 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2015 Yann Lanthony
+# Copyright (c) 2017-2018 Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (See LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+"""Test suite for qtsass."""
+
+# Standard library imports
 from __future__ import absolute_import
 import unittest
 from textwrap import dedent
+
+# Local imports
 from qtsass.qtsass import NotConformer, QLinearGradientConformer
 
 

--- a/test_qtsass.py
+++ b/test_qtsass.py
@@ -7,23 +7,23 @@ from qtsass.qtsass import NotConformer, QLinearGradientConformer
 
 class TestNotConformer(unittest.TestCase):
 
-    qss_str = "QAbstractItemView::item:!active"
-    css_str = "QAbstractItemView::item:_qnot_active"
+    qss_str = 'QAbstractItemView::item:!active'
+    css_str = 'QAbstractItemView::item:_qnot_active'
 
     def test_conform_to_css(self):
-        """NotConformer qss to css"""
+        """NotConformer qss to css."""
 
         c = NotConformer()
         self.assertEqual(c.to_css(self.qss_str), self.css_str)
 
     def test_conform_to_qss(self):
-        """NotConformer css to qss"""
+        """NotConformer css to qss."""
 
         c = NotConformer()
         self.assertEqual(c.to_qss(self.css_str), self.qss_str)
 
     def test_round_trip(self):
-        """NotConformer roundtrip"""
+        """NotConformer roundtrip."""
 
         c = NotConformer()
         conformed_css = c.to_css(self.qss_str)
@@ -32,19 +32,19 @@ class TestNotConformer(unittest.TestCase):
 
 class TestQLinearGradientConformer(unittest.TestCase):
 
-    css_vars_str = "qlineargradient($x1, $x2, $y1, $y2, (0 $red, 1 $blue))"
+    css_vars_str = 'qlineargradient($x1, $x2, $y1, $y2, (0 $red, 1 $blue))'
     qss_vars_str = (
-        "qlineargradient(x1:$x1, x2:$x2, y1:$y1, y2:$y2"
-        "stop: 0 $red, stop: 1 $blue)"
+        'qlineargradient(x1:$x1, x2:$x2, y1:$y1, y2:$y2'
+        'stop: 0 $red, stop: 1 $blue)'
     )
 
-    css_nostops_str = "qlineargradient(0, 0, 0, 0)"
-    qss_nostops_str = "qlineargradient(x1: 0, y1: 0, x2: 0, y2: 0)"
+    css_nostops_str = 'qlineargradient(0, 0, 0, 0)'
+    qss_nostops_str = 'qlineargradient(x1: 0, y1: 0, x2: 0, y2: 0)'
 
-    css_str = "qlineargradient(0, 0, 0, 0, (0 red, 1 blue))"
+    css_str = 'qlineargradient(0, 0, 0, 0, (0 red, 1 blue))'
     qss_singleline_str = (
-        "qlineargradient(x1: 0, y1: 0, x2: 0, y2: 0, "
-        "stop: 0 red, stop: 1 blue)"
+        'qlineargradient(x1: 0, y1: 0, x2: 0, y2: 0, '
+        'stop: 0 red, stop: 1 blue)'
     )
     qss_multiline_str = dedent("""
     qlineargradient(
@@ -57,43 +57,43 @@ class TestQLinearGradientConformer(unittest.TestCase):
     )
     """).strip()
     qss_weird_whitespace_str = (
-        "qlineargradient( x1: 0, y1:0, x2: 0, y2:0, "
-        "   stop:0 red, stop: 1 blue )"
+        'qlineargradient( x1: 0, y1:0, x2: 0, y2:0, '
+        '   stop:0 red, stop: 1 blue )'
     )
 
     def test_does_not_affect_css_form(self):
-        """QLinearGradientConformer does not affect css qlineargradient func"""
+        """QLinearGradientConformer no affect on css qlineargradient func."""
 
         c = QLinearGradientConformer()
         self.assertEqual(c.to_css(self.css_str), self.css_str)
         self.assertEqual(c.to_qss(self.css_str), self.css_str)
 
     def test_conform_singleline_str(self):
-        """QLinearGradientConformer singleline qss to css"""
+        """QLinearGradientConformer singleline qss to css."""
 
         c = QLinearGradientConformer()
         self.assertEqual(c.to_css(self.qss_singleline_str), self.css_str)
 
     def test_conform_multiline_str(self):
-        """QLinearGradientConformer multiline qss to css"""
+        """QLinearGradientConformer multiline qss to css."""
 
         c = QLinearGradientConformer()
         self.assertEqual(c.to_css(self.qss_multiline_str), self.css_str)
 
     def test_conform_weird_whitespace_str(self):
-        """QLinearGradientConformer weird whitespace qss to css"""
+        """QLinearGradientConformer weird whitespace qss to css."""
 
         c = QLinearGradientConformer()
         self.assertEqual(c.to_css(self.qss_weird_whitespace_str), self.css_str)
 
     def test_conform_nostops_str(self):
-        """QLinearGradientConformer qss with no stops to css"""
+        """QLinearGradientConformer qss with no stops to css."""
 
         c = QLinearGradientConformer()
         self.assertEqual(c.to_css(self.qss_nostops_str), self.css_nostops_str)
 
     def test_conform_vars_str(self):
-        """QLinearGradientConformer qss with vars to css"""
+        """QLinearGradientConformer qss with vars to css."""
 
         c = QLinearGradientConformer()
         self.assertEqual(c.to_css(self.qss_vars_str), self.css_vars_str)


### PR DESCRIPTION
Fixes #3 
Fixes #4

---

Hello, great project!

Found this while attempting to use libsass for a qt project and ran into a couple of issues.

First, I couldn't pip install qtsass. This fork has a standard setup.py that does not use cx_freeze. This makes it easier for me to install on windows/linux. I'm not sure if qtsass requires cx_freeze for spyder, but, for me it makes more sense to have a standard setup.py.

This fork also introduces an importer callback passed to libsass.compile that conforms scss imported using @import statements.

Finally, I introduced an abstraction around conforming css to qss and qss to css. This should make it easier to support more qss specific syntax in the future. For example, there could be a Conformer for qlineargradient that transforms the qss syntax:

`qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0.1 blue, stop: 0.8 green)`

to your libsass qlineargradient function syntax:

`qlineargradient(0, 0, 0, 1, (0.1 blue, 0.8 green))`