### PR TITLE
PR: Add support for compiling directories of QtSass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,3 +261,6 @@ atlassian-ide-plugin.xml
 com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
+
+# pytest
+.pytest_cache

--- a/examples/complex/_base.scss
+++ b/examples/complex/_base.scss
@@ -1,0 +1,4 @@
+@import 'defaults';
+@import 'widgets/qwidget';
+@import 'widgets/qpushbutton';
+@import 'widgets/qlineedit';

--- a/examples/complex/_defaults.scss
+++ b/examples/complex/_defaults.scss
@@ -1,0 +1,13 @@
+// Fonts
+$font-stack: Helvetica, sans-serif !default;
+
+// Colors
+$background: rgb(255, 255, 255) !default;
+$primary: rgb(35, 35, 35) !default;
+$accent: rgb(35, 75, 135) !default;
+
+// Paddings
+$text-padding: 16px 8px 16px 8px !default;
+
+// Borders
+$border-radius: 2px !default;

--- a/examples/complex/dark.scss
+++ b/examples/complex/dark.scss
@@ -1,0 +1,9 @@
+// Change default values
+
+$background: rgb(35, 35, 35);
+$primary: rgb(255, 255, 255);
+
+
+// Import base style
+
+@import 'base';

--- a/examples/complex/light.scss
+++ b/examples/complex/light.scss
@@ -1,0 +1,1 @@
+@import 'base';

--- a/examples/complex/widgets/_qlineedit.scss
+++ b/examples/complex/widgets/_qlineedit.scss
@@ -1,0 +1,6 @@
+QLineEdit {
+    color: $primary;
+    padding: $text-padding;
+    border: 0;
+    border-bottom: 1px solid $primary;
+}

--- a/examples/complex/widgets/_qpushbutton.scss
+++ b/examples/complex/widgets/_qpushbutton.scss
@@ -1,0 +1,13 @@
+QPushButton {
+    background: $background;
+    color: $accent;
+    padding: $text-padding;
+    border: 0;
+    border-radius: $border-radius;
+}
+
+QPushButton:hover,
+QPushButton:focus {
+    background: $accent;
+    color: $background;
+}

--- a/examples/complex/widgets/_qwidget.scss
+++ b/examples/complex/widgets/_qwidget.scss
@@ -1,0 +1,4 @@
+QWidget {
+    background: $background;
+    color: $primary;
+}

--- a/qtsass/__init__.py
+++ b/qtsass/__init__.py
@@ -11,7 +11,7 @@
 from __future__ import absolute_import
 
 # Local imports
-from qtsass.api import compile, compile_and_save
+from qtsass.api import compile, compile_filename, compile_dirname, watch
 
 
 VERSION_INFO = (0, 1, 0)

--- a/qtsass/__main__.py
+++ b/qtsass/__main__.py
@@ -11,10 +11,11 @@
 
 # Standard library imports
 from __future__ import absolute_import
+import sys
 
 # Local imports
 from qtsass import cli
 
 
 if __name__ == '__main__':
-    cli.main()
+    cli.main(sys.argv[1:])

--- a/qtsass/api.py
+++ b/qtsass/api.py
@@ -15,11 +15,13 @@ import os
 
 # Third party imports
 import sass
+from watchdog.observers import Observer
 
 # Local imports
 from qtsass.conformers import scss_conform, qt_conform
 from qtsass.functions import qlineargradient, rgba
 from qtsass.importers import qss_importer
+from qtsass.events import SourceEventHandler
 
 
 logging.basicConfig(level=logging.DEBUG)
@@ -27,6 +29,8 @@ _log = logging.getLogger(__name__)
 
 
 def compile(input_file):
+    """Compile QtSASS to CSS."""
+
     _log.debug('Compiling {}...'.format(input_file))
 
     with open(input_file, 'r') as f:
@@ -50,11 +54,57 @@ def compile(input_file):
     return ""
 
 
-def compile_and_save(input_file, dest_file):
-    stylesheet = compile(input_file)
-    if dest_file:
-        with open(dest_file, 'w') as css_file:
-            css_file.write(stylesheet)
-            _log.info('Created CSS file {}'.format(dest_file))
+def compile_filename(input_file, dest_file):
+    """Compile QtSASS to CSS and save."""
+
+    css = compile(input_file)
+    with open(dest_file, 'w') as css_file:
+        css_file.write(css)
+        _log.info('Created CSS file {}'.format(dest_file))
+
+
+def compile_dirname(input_dir, output_dir):
+    """Compiles QtSASS files in a directory including subdirectories."""
+
+    def is_valid(file):
+        return not file.startswith('_') and file.endswith('.scss')
+
+    for root, subdirs, files in os.walk(input_dir):
+        relative_root = os.path.relpath(root, input_dir)
+        output_root = os.path.join(output_dir, relative_root)
+
+        for file in [f for f in files if is_valid(f)]:
+            scss_path = os.path.join(root, file)
+            css_file = os.path.splitext(file)[0] + '.css'
+            css_path = os.path.join(output_root, css_file)
+            if not os.path.isdir(output_root):
+                os.makedirs(output_root)
+            compile_filename(scss_path, css_path)
+
+
+def watch(source, destination, compiler=None, recursive=True):
+    """
+    Watches a source file or directory, compiling QtSass files when modified.
+
+    The compiler function defaults to compile_filename when source is a file
+    and compile_dirname when source is a directory.
+
+    :param source: Path to source QtSass file or directory.
+    :param destination: Path to output css file or directory.
+    :param compiler: Compile function (optional)
+    :param recursive: If True, watch subdirectories (default: True).
+    :returns: watchdog.Observer
+    """
+
+    if os.path.isfile(source):
+        watch_dir = os.path.dirname(source)
+        compiler = compiler or compile_filename
     else:
-        print(stylesheet)
+        watch_dir = source
+        compiler = compiler or compile_dirname
+
+    event_handler = SourceEventHandler(source, destination, compiler)
+
+    observer = Observer()
+    observer.schedule(event_handler, watch_dir, recursive=recursive)
+    return observer

--- a/qtsass/cli.py
+++ b/qtsass/cli.py
@@ -13,15 +13,12 @@
 from __future__ import absolute_import, print_function
 import argparse
 import os
+import sys
 import time
 import logging
 
-# Third party imports
-from watchdog.observers import Observer
-
 # Local imports
-from qtsass.api import compile_and_save
-from qtsass.events import SourceModificationEventHandler
+from qtsass.api import compile, compile_filename, compile_dirname, watch
 
 
 logging.basicConfig(level=logging.DEBUG)
@@ -55,19 +52,31 @@ def main():
     """qtsass's cli entry point."""
 
     args = main_parser().parse_args()
-    compile_and_save(args.input, args.output)
+    file_mode = os.path.isfile(args.input)
+    dir_mode = os.path.isdir(args.input)
+
+    if file_mode and not args.output:
+        css = compile(args.input)
+        print(css)
+        sys.exit(0)
+
+    elif file_mode:
+        compile_filename(args.input, args.output)
+
+    elif dir_mode and not args.output:
+        print('Error: missing required option: -o/--output')
+        sys.exit(1)
+
+    elif dir_mode:
+        compile_dirname(args.input, args.output)
+
+    else:
+        print('Error: input must be a file or a directory')
+        sys.exit(1)
 
     if args.watch:
-        watched_dir = os.path.abspath(os.path.dirname(args.input))
-        event_handler = SourceModificationEventHandler(
-            args.input,
-            args.output,
-            watched_dir,
-            compile_and_save
-        )
         _log.info('qtsass is watching {}...'.format(args.input))
-        observer = Observer()
-        observer.schedule(event_handler, watched_dir, recursive=False)
+        observer = watch(args.input, args.output)
         observer.start()
         try:
             while True:

--- a/qtsass/cli.py
+++ b/qtsass/cli.py
@@ -16,6 +16,7 @@ import os
 import sys
 import time
 import logging
+import signal
 
 # Local imports
 from qtsass.api import compile, compile_filename, compile_dirname, watch
@@ -25,7 +26,7 @@ logging.basicConfig(level=logging.DEBUG)
 _log = logging.getLogger(__name__)
 
 
-def main_parser():
+def create_parser():
     """Create qtsass's cli parser."""
 
     parser = argparse.ArgumentParser(
@@ -48,10 +49,10 @@ def main_parser():
     return parser
 
 
-def main():
+def main(args):
     """qtsass's cli entry point."""
 
-    args = main_parser().parse_args()
+    args = create_parser().parse_args(args)
     file_mode = os.path.isfile(args.input)
     dir_mode = os.path.isdir(args.input)
 
@@ -84,3 +85,4 @@ def main():
         except KeyboardInterrupt:
             observer.stop()
         observer.join()
+        sys.exit(0)

--- a/qtsass/conformers.py
+++ b/qtsass/conformers.py
@@ -6,7 +6,7 @@
 # Licensed under the terms of the MIT License
 # (See LICENSE.txt for details)
 # -----------------------------------------------------------------------------
-"""Conform qss to compliant scss and css to valid qss."""
+"""Conform qss to compliant scss and css to valid qss."""
 
 # Standard library imports
 from __future__ import absolute_import, print_function
@@ -134,4 +134,5 @@ def qt_conform(input_str):
     conformed = input_str
     for conformer in conformers[::-1]:
         conformed = conformer.to_qss(conformed)
+
     return conformed

--- a/qtsass/events.py
+++ b/qtsass/events.py
@@ -8,54 +8,17 @@
 # -----------------------------------------------------------------------------
 """Source files event handler."""
 
-# Standard library imports
-import os
-import time
-
 # Third party imports
 from watchdog.events import FileSystemEventHandler
 
 
-# py2 has no FileNotFoundError
-try:
-    FileNotFoundError
-except NameError:
-    FileNotFoundError = IOError
+class SourceEventHandler(FileSystemEventHandler):
 
-
-class SourceModificationEventHandler(FileSystemEventHandler):
-
-    def __init__(self, input_file, dest_file, watched_dir, compiler):
-        super(SourceModificationEventHandler, self).__init__()
-        self._input_file = input_file
-        self._dest_file = dest_file
+    def __init__(self, source, destination, compiler):
+        super(SourceEventHandler, self).__init__()
+        self._source = source
+        self._destination = destination
         self._compiler = compiler
-        self._watched_dir = watched_dir
-        self._watched_extension = os.path.splitext(self._input_file)[1]
-
-    def _recompile(self):
-        i = 0
-        success = False
-        while i < 10 and not success:
-            try:
-                time.sleep(0.2)
-                self._compiler(self._input_file, self._dest_file)
-                success = True
-            except FileNotFoundError:
-                i += 1
 
     def on_modified(self, event):
-        # On Mac, event will always be a directory.
-        # On Windows, only recompile if event's file
-        # has the same extension as the input file
-        we_should_recompile = (
-            event.is_directory and
-            os.path.samefile(event.src_path, self._watched_dir) or
-            os.path.splitext(event.src_path)[1] == self._watched_extension
-        )
-        if we_should_recompile:
-            self._recompile()
-
-    def on_created(self, event):
-        if os.path.splitext(event.src_path)[1] == self._watched_extension:
-            self._recompile()
+        self._compiler(self._source, self._destination)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -182,6 +182,8 @@ def test_watch_complex(tmpdir):
     assert touch_and_wait(input_partial)
     assert touch_and_wait(input_nested)
 
+    proc.terminate()
+
 
 def test_invalid_input():
     """CLI input is not a file or dir."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,8 +56,6 @@ def invoke(args):
         stderr=PIPE,
         cwd=PROJECT_DIR
     )
-    if PY3:
-        kwargs['encoding'] = 'utf8'
     proc = Popen(['python', '-m', 'qtsass'] + args, **kwargs)
     return proc
 
@@ -67,6 +65,8 @@ def invoke_with_result(args):
 
     proc = invoke(args)
     out, err = proc.communicate()
+    out = out.decode('ascii', errors="ignore")
+    err = err.decode('ascii', errors="ignore")
     return Result(proc.returncode, out, err)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,203 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2015 Yann Lanthony
+# Copyright (c) 2017-2018 Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (See LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+"""Test qtsass cli."""
+
+# Standard library imports
+from __future__ import absolute_import
+import os
+import time
+import signal
+import sys
+from os.path import join, dirname, normpath, exists, basename
+from textwrap import dedent
+from subprocess import Popen, PIPE
+from collections import namedtuple
+
+
+PY3 = sys.version_info.major == 3
+PROJECT_DIR = normpath(dirname(dirname(__file__)))
+Result = namedtuple('Result', "code stdout stderr")
+
+
+def example(*paths):
+    """Get path to an example."""
+
+    return normpath(join(dirname(__file__), '..', 'examples', *paths))
+
+
+def touch(file):
+    """Touch a file."""
+
+    with open(file, 'a') as f:
+        os.utime(file, None)
+
+
+def await_condition(condition, timeout=2000):
+    """Return True if a condition is met in the given timeout period"""
+
+    for _ in range(timeout):
+        if condition():
+            return True
+        time.sleep(0.001)
+    return False
+
+
+def invoke(args):
+    """Invoke qtsass cli with specified args"""
+
+    kwargs = dict(
+        stdout=PIPE,
+        stderr=PIPE,
+        cwd=PROJECT_DIR
+    )
+    if PY3:
+        kwargs['encoding'] = 'utf8'
+    proc = Popen(['python', '-m', 'qtsass'] + args, **kwargs)
+    return proc
+
+
+def invoke_with_result(args):
+    """Invoke qtsass cli and return a Result obj"""
+
+    proc = invoke(args)
+    out, err = proc.communicate()
+    return Result(proc.returncode, out, err)
+
+
+def test_compile_dummy_to_stdout():
+    """CLI compile dummy example to stdout."""
+
+    args = [example('dummy.scss')]
+    result = invoke_with_result(args)
+
+    assert result.code == 0
+    assert result.stdout
+
+
+def test_compile_dummy_to_file(tmpdir):
+    """CLI compile dummy example to file."""
+
+    input = example('dummy.scss')
+    output = tmpdir.join('dummy.css')
+    args = [input, '-o', output.strpath]
+    result = invoke_with_result(args)
+
+    assert result.code == 0
+    assert exists(output.strpath)
+
+
+def test_watch_dummy(tmpdir):
+    """CLI watch dummy example."""
+
+    input = example('dummy.scss')
+    output = tmpdir.join('dummy.css')
+    args = [input, '-o', output.strpath, '-w']
+    proc = invoke(args)
+
+    # Wait for initial compile
+    output_exists = lambda: exists(output.strpath)
+    if not await_condition(output_exists):
+        proc.terminate()
+        assert False, "Failed to compile dummy.scss"
+
+    # Ensure subprocess is still alive
+    assert proc.poll() is None
+
+    # Touch input file, triggering a recompile
+    created = output.mtime()
+    file_modified = lambda: output.mtime() > created
+    time.sleep(0.1)
+    touch(input)
+
+    if not await_condition(file_modified):
+        proc.terminate()
+        assert False, 'Output file has not been recompiled...'
+
+    proc.terminate()
+
+
+def test_compile_complex(tmpdir):
+    """CLI compile complex example."""
+
+    input = example('complex')
+    output = tmpdir.mkdir('output')
+    args = [input, '-o', output.strpath]
+    result = invoke_with_result(args)
+
+    assert result.code == 0
+
+    expected_files = [output.join('light.css'), output.join('dark.css')]
+    for file in expected_files:
+        assert exists(file.strpath)
+
+
+def test_watch_complex(tmpdir):
+    """CLI watch complex example."""
+
+    input = example('complex')
+    output = tmpdir.mkdir('output')
+    args = [input, '-o', output.strpath, '-w']
+    proc = invoke(args)
+
+    expected_files = [output.join('light.css'), output.join('dark.css')]
+
+    # Wait for initial compile
+    files_created = lambda: all([exists(f.strpath) for f in expected_files])
+    if not await_condition(files_created):
+        assert False, 'All expected files have not been created...'
+
+    # Ensure subprocess is still alive
+    assert proc.poll() is None
+
+    # Input files to touch
+    input_full = example('complex', 'light.scss')
+    input_partial = example('complex', '_base.scss')
+    input_nested = example('complex', 'widgets', '_qwidget.scss')
+
+    def touch_and_wait(input_file, timeout=2000):
+        """Touch a file, triggering a recompile"""
+
+        filename = basename(input_file)
+        old_mtimes = [f.mtime() for f in expected_files]
+        files_modified = lambda: all(
+            [f.mtime() > old_mtimes[i] for i, f in enumerate(expected_files)]
+        )
+        time.sleep(0.1)
+        touch(input_file)
+
+        if not await_condition(files_modified, timeout):
+            proc.terminate()
+            err = 'Modifying %s did not trigger recompile.' % filename
+            assert False, err
+
+        return True
+
+    assert touch_and_wait(input_full)
+    assert touch_and_wait(input_partial)
+    assert touch_and_wait(input_nested)
+
+
+def test_invalid_input():
+    """CLI input is not a file or dir."""
+
+    proc = invoke_with_result(['file_does_not_exist.scss'])
+    assert proc.code == 1
+    assert 'Error: input must be' in proc.stdout
+
+    proc = invoke_with_result(['./dir/does/not/exist'])
+    assert proc.code == 1
+    assert 'Error: input must be' in proc.stdout
+
+
+def test_dir_missing_output():
+    """CLI dir missing output option"""
+
+    proc = invoke_with_result([example('complex')])
+    assert proc.code == 1
+    assert 'Error: missing required option' in proc.stdout

--- a/tests/test_conformers.py
+++ b/tests/test_conformers.py
@@ -6,7 +6,7 @@
 # Licensed under the terms of the MIT License
 # (See LICENSE.txt for details)
 # -----------------------------------------------------------------------------
-"""Test suite for qtsass."""
+"""Test qtsass conformers."""
 
 # Standard library imports
 from __future__ import absolute_import


### PR DESCRIPTION
resolves #18

- Added complex example including imports from subdirectories and partial files
- Simplified watchdog event handler
  - Now we just recompile anytime the source directory changes
  - This is far more reliable and accounts for imports
  - Removes weird logic to work around MacOS fsEvents
- Aligned api compile* names with libsass
- Decided not to modify cli arguments as discussed in #18 since *input* works fine for files or directories

I think the compile methods should be aligned closer to libsass in that sass.compile handles strings, files, and directories and delegates to sass.compile_filename and sass.compile_dirname. This pull request lays the foundation to achieve that by renaming compile_and_save to compile_filename and adding the compile_dirname method.