### PR TITLE
Fix Setuptools CLI entry point

### DIFF
--- a/qtsass/__main__.py
+++ b/qtsass/__main__.py
@@ -17,5 +17,10 @@ import sys
 from qtsass import cli
 
 
-if __name__ == '__main__':
+def entry_point():
+    """qtsass's CLI entry point."""
+
     cli.main(sys.argv[1:])
+
+if __name__ == '__main__':
+    entry_point()

--- a/qtsass/cli.py
+++ b/qtsass/cli.py
@@ -50,7 +50,7 @@ def create_parser():
 
 
 def main(args):
-    """qtsass's cli entry point."""
+    """Run the CLI with the given arguments."""
 
     args = create_parser().parse_args(args)
     file_mode = os.path.isfile(args.input)

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     packages=find_packages(),
     entry_points={
         'console_scripts': [
-            'qtsass = qtsass.cli:main'
+            'qtsass = qtsass.__main__:entry_point'
         ]
     },
     classifiers=(


### PR DESCRIPTION
It looks like this was broken in the move to `cli.py` in Git commit 25d622a7479ab3b5d544738aa27e314666cc688e.

Feel free to change the docstrings or how it's implemented — I primarily wanted to report the bug, but the fix was easy enough that I just did it.

Thanks for maintaining qtsass!