### PR TITLE
FIXED: to allow rgba() inside qlineargradient() stops

### DIFF
--- a/qtsass/functions.py
+++ b/qtsass/functions.py
@@ -49,15 +49,16 @@ def qlineargradient(x1, y1, x2, y2, stops):
     :type stops: sass.SassList
     :return:
     """
-    stops_str = ''
+
+    stops_str = []
     for stop in stops[0]:
         pos, color = stop[0]
-        stops_str += ' stop: {} {}'.format(pos.value, rgba_from_color(color))
+        stops_str.append('stop: {} {}'.format(pos.value, rgba_from_color(color)))
 
-    return 'qlineargradient(x1: {}, y1: {}, x2: {}, y2: {},{})'.format(
+    return 'qlineargradient(x1: {}, y1: {}, x2: {}, y2: {}, {})'.format(
         x1.value,
         y1.value,
         x2.value,
         y2.value,
-        stops_str.rstrip(',')
+        ', '.join(stops_str)
     )

--- a/qtsass/functions.py
+++ b/qtsass/functions.py
@@ -31,6 +31,10 @@ def rgba_from_color(color):
 
     :type color: sass.SassColor
     """
+    # Inner rgba() call
+    if not isinstance(color, sass.SassColor):
+        return '{}'.format(color)
+
     return rgba(color.r, color.g, color.b, color.a)
 
 

--- a/tests/test_conformers.py
+++ b/tests/test_conformers.py
@@ -124,4 +124,4 @@ class TestQLinearGradientConformer(unittest.TestCase):
 
         c = QLinearGradientConformer()
         #self.assertEqual(c.to_scss(self.qss_rgba_str), self.css_rgba_str)
-        print('TODO: QSS to SCSS with nestest qlineargradient(rgba())')
+        print('TODO: QSS to SCSS with nested qlineargradient(rgba())')

--- a/tests/test_conformers.py
+++ b/tests/test_conformers.py
@@ -73,6 +73,15 @@ class TestQLinearGradientConformer(unittest.TestCase):
         '   stop:0 red, stop: 1 blue )'
     )
 
+    css_rgba_str = (
+        'qlineargradient(0, 0, 0, 0,'
+        '   (0 rgba(0, 1, 2, 0.3), 0.99 rgba(7, 8, 9, 1)))'
+    )
+    qss_rgba_str = (
+        'qlineargradient(x1: 0, y1: 0, x2: 0, y2: 0, '
+        'stop: 0 rgba(0, 1, 2, 30%), stop: 0.99 rgba(7, 8, 9, 100%))'
+    )
+
     def test_does_not_affect_css_form(self):
         """QLinearGradientConformer no affect on css qlineargradient func."""
 
@@ -109,3 +118,10 @@ class TestQLinearGradientConformer(unittest.TestCase):
 
         c = QLinearGradientConformer()
         self.assertEqual(c.to_scss(self.qss_vars_str), self.css_vars_str)
+
+    def test_conform_rgba_str(self):
+        """QLinearGradientConformer qss with vars to scss."""
+
+        c = QLinearGradientConformer()
+        #self.assertEqual(c.to_scss(self.qss_rgba_str), self.css_rgba_str)
+        print('TODO: QSS to SCSS with nestest qlineargradient(rgba())')

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2015 Yann Lanthony
+# Copyright (c) 2017-2018 Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (See LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+"""Test qtsass conformers."""
+
+# Standard library imports
+from __future__ import absolute_import
+import unittest
+from textwrap import dedent
+import sass
+
+# Local imports
+from qtsass.api import compile_source
+
+class BaseCompileTest(unittest.TestCase):
+    def compile_scss(self, str):
+        # NOTE: revise for better future compatibility
+        wstr = '*{{t: {0};}}'.format(str)
+        res = compile_source(wstr, __file__)
+        return res.replace('* {\n  t: ', '').replace('; }\n', '')
+
+class TestRgbaFunc(BaseCompileTest):
+    def test_rgba(self):
+        self.assertEqual(
+            self.compile_scss('rgba(0, 1, 2, 0.3)'),
+            'rgba(0, 1, 2, 30%)'
+        )
+
+class TestQLinearGradientFunc(BaseCompileTest):
+    def test_color(self):
+        self.assertEqual(
+            self.compile_scss('qlineargradient(1, 2, 3, 4, (0 red, 1 blue))'),
+            'qlineargradient(x1: 1.0, y1: 2.0, x2: 3.0, y2: 4.0, '
+            'stop: 0.0 rgba(255, 0, 0, 100%), stop: 1.0 rgba(0, 0, 255, 100%))'
+        )
+
+    def test_rgba(self):
+        self.assertEqual(
+            self.compile_scss('qlineargradient(1, 2, 3, 4, (0 red, 0.2 rgba(5, 6, 7, 0.8)))'),
+            'qlineargradient(x1: 1.0, y1: 2.0, x2: 3.0, y2: 4.0, '
+            'stop: 0.0 rgba(255, 0, 0, 100%), stop: 0.2 rgba(5, 6, 7, 80%))'
+        )

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -15,13 +15,13 @@ from textwrap import dedent
 import sass
 
 # Local imports
-from qtsass.api import compile_source
+from qtsass.api import compile
 
 class BaseCompileTest(unittest.TestCase):
     def compile_scss(self, str):
         # NOTE: revise for better future compatibility
         wstr = '*{{t: {0};}}'.format(str)
-        res = compile_source(wstr, __file__)
+        res = compile(wstr)
         return res.replace('* {\n  t: ', '').replace('; }\n', '')
 
 class TestRgbaFunc(BaseCompileTest):


### PR DESCRIPTION
Current code fails with something like `qlineargradient(0, 0, 1,1, (0.1 rgba(0,0,0,0.5)))`.

A quick non-intrusive workaround is provided.