### PR TITLE
added support for incomplete coords and incoming %-rgba values ...

### DIFF
--- a/qtsass/api.py
+++ b/qtsass/api.py
@@ -108,6 +108,7 @@ def compile_filename(input_file, output_file, **kwargs):
     :param input_file: Path to QtSass file.
     :param output_file: Path to write Qt compliant CSS.
     :param kwargs: Keyword arguments to pass to sass.compile
+    :returns: CSS string
     """
     input_root = os.path.abspath(os.path.dirname(input_file))
     kwargs.setdefault('include_paths', [input_root])
@@ -121,6 +122,7 @@ def compile_filename(input_file, output_file, **kwargs):
     with open(output_file, 'w') as css_file:
         css_file.write(css)
         _log.info('Created CSS file {}'.format(os.path.normpath(output_file)))
+    return css
 
 
 def compile_dirname(input_dir, output_dir, **kwargs):

--- a/qtsass/api.py
+++ b/qtsass/api.py
@@ -18,10 +18,6 @@ import logging
 import os
 
 # Third party imports
-try:
-    from watchdog.observers import Observer
-except ImportError:
-    Observer = None
 import sass
 
 # Local imports
@@ -29,6 +25,12 @@ from qtsass.conformers import qt_conform, scss_conform
 from qtsass.events import SourceEventHandler
 from qtsass.functions import qlineargradient, rgba
 from qtsass.importers import qss_importer
+
+
+try:
+    from watchdog.observers import Observer
+except ImportError:
+    Observer = None
 
 
 # yapf: enable

--- a/qtsass/api.py
+++ b/qtsass/api.py
@@ -142,18 +142,18 @@ def compile_dirname(input_dir, output_dir, **kwargs):
     """
     kwargs.setdefault('include_paths', [input_dir])
 
-    def is_valid(file):
-        return not file.startswith('_') and file.endswith('.scss')
+    def is_valid(file_name):
+        return not file_name.startswith('_') and file_name.endswith('.scss')
 
-    for root, subdirs, files in os.walk(input_dir):
+    for root, _, files in os.walk(input_dir):
         relative_root = os.path.relpath(root, input_dir)
         output_root = os.path.join(output_dir, relative_root)
         fkwargs = dict(kwargs)
         fkwargs['include_paths'] = fkwargs['include_paths'] + [root]
 
-        for file in [f for f in files if is_valid(f)]:
-            scss_path = os.path.join(root, file)
-            css_file = os.path.splitext(file)[0] + '.css'
+        for file_name in [f for f in files if is_valid(f)]:
+            scss_path = os.path.join(root, file_name)
+            css_file = os.path.splitext(file_name)[0] + '.css'
             css_path = os.path.join(output_root, css_file)
 
             if not os.path.isdir(output_root):

--- a/qtsass/api.py
+++ b/qtsass/api.py
@@ -18,6 +18,7 @@ import logging
 import os
 
 # Third party imports
+from watchdog.observers import Observer
 import sass
 
 # Local imports
@@ -25,12 +26,6 @@ from qtsass.conformers import qt_conform, scss_conform
 from qtsass.events import SourceEventHandler
 from qtsass.functions import qlineargradient, rgba
 from qtsass.importers import qss_importer
-
-
-try:
-    from watchdog.observers import Observer
-except ImportError:
-    Observer = None
 
 
 # yapf: enable
@@ -177,11 +172,6 @@ def watch(source, destination, compiler=None, recursive=True):
     :param recursive: If True, watch subdirectories (default: True).
     :returns: watchdog.Observer
     """
-    if Observer is None:
-        raise RuntimeError(
-            'Unable to use Observer class from watchdog.observers!\n'
-            'You need to install watchdog first!')
-
     if os.path.isfile(source):
         watch_dir = os.path.dirname(source)
         compiler = compiler or compile_filename

--- a/qtsass/api.py
+++ b/qtsass/api.py
@@ -18,7 +18,10 @@ import logging
 import os
 
 # Third party imports
-from watchdog.observers import Observer
+try:
+    from watchdog.observers import Observer
+except ImportError:
+    Observer = None
 import sass
 
 # Local imports
@@ -172,6 +175,11 @@ def watch(source, destination, compiler=None, recursive=True):
     :param recursive: If True, watch subdirectories (default: True).
     :returns: watchdog.Observer
     """
+    if Observer is None:
+        raise RuntimeError(
+            'Unable to use Observer class from watchdog.observers!\n'
+            'You need to install watchdog first!')
+
     if os.path.isfile(source):
         watch_dir = os.path.dirname(source)
         compiler = compiler or compile_filename

--- a/qtsass/conformers.py
+++ b/qtsass/conformers.py
@@ -18,6 +18,8 @@ import re
 
 # yapf: enable
 
+_DEFAULT_COORDS = ('x1', 'y1', 'x2', 'y2')
+
 
 class Conformer(object):
     """Base class for all text transformations."""
@@ -54,11 +56,28 @@ class QLinearGradientConformer(Conformer):
         re.MULTILINE,
     )
 
-    def _conform_group_to_scss(self, group):
+    def _conform_coords_to_scss(self, group):
         """
-        Take a qss str with xy coords/stops and return the values.
+        Take a qss str with xy coords and returns the values.:
+          'x1: 0, y1: 0, x2: 0, y2: 0' => '0, 0, 0, 0'
+          'y1: 1' => '0, 1, 0, 0'
+        """
+        values = ['0', '0', '0', '0']
+        for key_values in [part.split(':', 1) for part in group.split(',')]:
+            try:
+                key, value = key_values
+                key = key.strip()
+                if key in _DEFAULT_COORDS:
+                    pos = _DEFAULT_COORDS.index(key)
+                    if pos >= 0 and pos <= 3:
+                        values[pos] = value.strip()
+            except ValueError:
+                pass
+        return ', '.join(values)
 
-        'x1: 0, y1: 0, x2: 0, y2: 0' => '0, 0, 0, 0'
+    def _conform_stops_to_scss(self, group):
+        """
+        Take a qss str with stops and returns the values.:
         'stop: 0 red, stop: 1 blue' => '0 red, 1 blue'
         """
         new_group = []
@@ -93,13 +112,13 @@ class QLinearGradientConformer(Conformer):
         conformed = qss
 
         for coords, stops in self.qss_pattern.findall(qss):
-            new_coords = self._conform_group_to_scss(coords)
+            new_coords = self._conform_coords_to_scss(coords)
             conformed = conformed.replace(coords, new_coords, 1)
 
             if not stops:
                 continue
 
-            new_stops = ', ({})'.format(self._conform_group_to_scss(stops))
+            new_stops = ', ({})'.format(self._conform_stops_to_scss(stops))
             conformed = conformed.replace(stops, new_stops, 1)
 
         return conformed

--- a/qtsass/conformers.py
+++ b/qtsass/conformers.py
@@ -48,7 +48,7 @@ class QLinearGradientConformer(Conformer):
 
     qss_pattern = re.compile(
         r'qlineargradient\('
-        r'((?:(?:\s+)?(?:x1|y1|x2|y2):(?:\s+)?[0-9A-Za-z$_-]+,?)+)'  # coords
+        r'((?:(?:\s+)?(?:x1|y1|x2|y2):(?:\s+)?[0-9A-Za-z$_\.-]+,?)+)'  # coords
         r'((?:(?:\s+)?stop:.*,?)+(?:\s+)?)?'  # stops
         r'\)',
         re.MULTILINE,

--- a/qtsass/conformers.py
+++ b/qtsass/conformers.py
@@ -23,6 +23,7 @@ _DEFAULT_COORDS = ('x1', 'y1', 'x2', 'y2')
 
 class Conformer(object):
     """Base class for all text transformations."""
+
     def to_scss(self, qss):
         """Transform some qss to valid scss."""
         return NotImplemented
@@ -34,6 +35,7 @@ class Conformer(object):
 
 class NotConformer(Conformer):
     """Conform QSS "!" in selectors."""
+
     def to_scss(self, qss):
         """Replace "!" in selectors with "_qnot_"."""
         return qss.replace(':!', ':_qnot_')

--- a/qtsass/conformers.py
+++ b/qtsass/conformers.py
@@ -23,7 +23,6 @@ _DEFAULT_COORDS = ('x1', 'y1', 'x2', 'y2')
 
 class Conformer(object):
     """Base class for all text transformations."""
-
     def to_scss(self, qss):
         """Transform some qss to valid scss."""
         return NotImplemented
@@ -35,7 +34,6 @@ class Conformer(object):
 
 class NotConformer(Conformer):
     """Conform QSS "!" in selectors."""
-
     def to_scss(self, qss):
         """Replace "!" in selectors with "_qnot_"."""
         return qss.replace(':!', ':_qnot_')

--- a/qtsass/conformers.py
+++ b/qtsass/conformers.py
@@ -58,7 +58,8 @@ class QLinearGradientConformer(Conformer):
 
     def _conform_coords_to_scss(self, group):
         """
-        Take a qss str with xy coords and returns the values.:
+        Take a qss str with xy coords and returns the values.
+
           'x1: 0, y1: 0, x2: 0, y2: 0' => '0, 0, 0, 0'
           'y1: 1' => '0, 1, 0, 0'
         """
@@ -77,8 +78,9 @@ class QLinearGradientConformer(Conformer):
 
     def _conform_stops_to_scss(self, group):
         """
-        Take a qss str with stops and returns the values.:
-        'stop: 0 red, stop: 1 blue' => '0 red, 1 blue'
+        Take a qss str with stops and returns the values.
+
+          'stop: 0 red, stop: 1 blue' => '0 red, 1 blue'
         """
         new_group = []
         split = [""]

--- a/qtsass/events.py
+++ b/qtsass/events.py
@@ -16,10 +16,12 @@ try:
 
     # yapf: enable
     class SourceEventHandler(FileSystemEventHandler):
-        """File handler to call sass compiler on_modified event."""
+        """File event handler to call sass compiler on_modified."""
 
         def __init__(self, source, destination, compiler):
             """
+            Create instance of the file event handler.
+
             :param str source: String path to qss source file.
             :param str source: String path to compiled target file.
             :param function compiler: Function object to call when
@@ -31,7 +33,7 @@ try:
             self._compiler = compiler
 
         def on_modified(self, _event):
-            """Calls sass compiler function object"""
+            """Call sass compiler function object."""
             self._compiler(self._source, self._destination)
 
 except ImportError:

--- a/qtsass/events.py
+++ b/qtsass/events.py
@@ -8,33 +8,31 @@
 # -----------------------------------------------------------------------------
 """Source files event handler."""
 
-try:
-    # yapf: disable
+# yapf: disable
 
-    # Third party imports
-    from watchdog.events import FileSystemEventHandler
+# Third party imports
+from watchdog.events import FileSystemEventHandler
 
-    # yapf: enable
-    class SourceEventHandler(FileSystemEventHandler):
-        """File event handler to call sass compiler on_modified."""
 
-        def __init__(self, source, destination, compiler):
-            """
-            Create instance of the file event handler.
+# yapf: enable
 
-            :param str source: String path to qss source file.
-            :param str source: String path to compiled target file.
-            :param function compiler: Function object to call when
-                source was modified.
-            """
-            super(SourceEventHandler, self).__init__()
-            self._source = source
-            self._destination = destination
-            self._compiler = compiler
 
-        def on_modified(self, _event):
-            """Call sass compiler function object."""
-            self._compiler(self._source, self._destination)
+class SourceEventHandler(FileSystemEventHandler):
+    """File event handler to call sass compiler on_modified."""
+    def __init__(self, source, destination, compiler):
+        """
+        Create instance of the file event handler.
 
-except ImportError:
-    SourceEventHandler = None
+        :param str source: String path to qss source file.
+        :param str source: String path to compiled target file.
+        :param function compiler: Function object to call when
+            source was modified.
+        """
+        super(SourceEventHandler, self).__init__()
+        self._source = source
+        self._destination = destination
+        self._compiler = compiler
+
+    def on_modified(self, _event):
+        """Call sass compiler function."""
+        self._compiler(self._source, self._destination)

--- a/qtsass/events.py
+++ b/qtsass/events.py
@@ -17,7 +17,6 @@ try:
     # yapf: enable
     class SourceEventHandler(FileSystemEventHandler):
         """File event handler to call sass compiler on_modified."""
-
         def __init__(self, source, destination, compiler):
             """
             Create instance of the file event handler.

--- a/qtsass/events.py
+++ b/qtsass/events.py
@@ -16,14 +16,22 @@ try:
 
     # yapf: enable
     class SourceEventHandler(FileSystemEventHandler):
+        """File handler to call sass compiler on_modified event."""
 
         def __init__(self, source, destination, compiler):
+            """
+            :param str source: String path to qss source file.
+            :param str source: String path to compiled target file.
+            :param function compiler: Function object to call when
+                source was modified.
+            """
             super(SourceEventHandler, self).__init__()
             self._source = source
             self._destination = destination
             self._compiler = compiler
 
         def on_modified(self, _event):
+            """Calls sass compiler function object"""
             self._compiler(self._source, self._destination)
 
 except ImportError:

--- a/qtsass/events.py
+++ b/qtsass/events.py
@@ -8,25 +8,23 @@
 # -----------------------------------------------------------------------------
 """Source files event handler."""
 
-# yapf: disable
+try:
+    # yapf: disable
 
-# Third party imports
-from watchdog.events import FileSystemEventHandler
+    # Third party imports
+    from watchdog.events import FileSystemEventHandler
 
+    # yapf: enable
+    class SourceEventHandler(FileSystemEventHandler):
 
-# yapf: enable
+        def __init__(self, source, destination, compiler):
+            super(SourceEventHandler, self).__init__()
+            self._source = source
+            self._destination = destination
+            self._compiler = compiler
 
+        def on_modified(self, _event):
+            self._compiler(self._source, self._destination)
 
-class SourceEventHandler(FileSystemEventHandler):
-    """Source event hanlder."""
-
-    def __init__(self, source, destination, compiler):
-        """Source event hanlder."""
-        super(SourceEventHandler, self).__init__()
-        self._source = source
-        self._destination = destination
-        self._compiler = compiler
-
-    def on_modified(self, event):
-        """Override watchdog method to handle on file modification events."""
-        self._compiler(self._source, self._destination)
+except ImportError:
+    SourceEventHandler = None

--- a/qtsass/events.py
+++ b/qtsass/events.py
@@ -17,6 +17,7 @@ try:
     # yapf: enable
     class SourceEventHandler(FileSystemEventHandler):
         """File event handler to call sass compiler on_modified."""
+
         def __init__(self, source, destination, compiler):
             """
             Create instance of the file event handler.

--- a/qtsass/functions.py
+++ b/qtsass/functions.py
@@ -18,10 +18,24 @@ import sass
 
 
 def rgba(r, g, b, a):
-    """Convert r,g,b,a values to standard format."""
+    """Convert r,g,b,a values to standard format.
+
+    Where `a` is alpha! In CSS alpha can be given as:
+     * float from 0.0 (fully transparent) to 1.0 (opaque)
+    In Qt or qss that is:
+     * int from 0 (fully transparent) to 255 (opaque)
+    A percentage value 0% (fully transparent) to 100% (opaque) works
+    in BOTH systems the same way!
+    """
     result = 'rgba({}, {}, {}, {}%)'
     if isinstance(r, sass.SassNumber):
-        alpha = a.value if a.unit == '%' else a.value * 100
+        if a.unit == '%':
+            alpha = a.value
+        elif a.value > 1.0:
+            # A value from 0 to 255 is coming in, convert to %
+            alpha = a.value / 2.55
+        else:
+            alpha = a.value * 100
         return result.format(int(r.value), int(g.value), int(b.value),
                              int(alpha))
     elif isinstance(r, float):

--- a/qtsass/functions.py
+++ b/qtsass/functions.py
@@ -22,8 +22,8 @@ def rgba(r, g, b, a):
     result = 'rgba({}, {}, {}, {}%)'
     if isinstance(r, sass.SassNumber):
         alpha = a.value if a.unit == '%' else a.value * 100
-        return result.format(
-            int(r.value), int(g.value), int(b.value), int(alpha))
+        return result.format(int(r.value), int(g.value), int(b.value),
+                             int(alpha))
     elif isinstance(r, float):
         return result.format(int(r), int(g), int(b), int(a * 100))
 

--- a/qtsass/functions.py
+++ b/qtsass/functions.py
@@ -21,8 +21,9 @@ def rgba(r, g, b, a):
     """Convert r,g,b,a values to standard format."""
     result = 'rgba({}, {}, {}, {}%)'
     if isinstance(r, sass.SassNumber):
+        alpha = a.value if a.unit == '%' else a.value * 100
         return result.format(
-            int(r.value), int(g.value), int(b.value), int(a.value * 100))
+            int(r.value), int(g.value), int(b.value), int(alpha))
     elif isinstance(r, float):
         return result.format(int(r), int(g), int(b), int(a * 100))
 

--- a/run_checks_and_format.py
+++ b/run_checks_and_format.py
@@ -54,14 +54,6 @@ def repo_changes():
 def run():
     """Run linters and formatters."""
 
-    # make sure scripts are available in environment paths
-    if sys.platform == 'win32':
-        scripts_dir = os.path.join(os.path.dirname(sys.executable), 'Scripts')
-        if scripts_dir not in os.environ['PATH']:
-            paths = os.environ['PATH'].split(';')
-            paths.append(scripts_dir)
-            os.environ['PATH'] = ';'.join(paths)
-
     for cmd_list in COMMANDS:
         cmd_str = ' '.join(cmd_list)
         print('\nRunning: ' + cmd_str)

--- a/run_checks_and_format.py
+++ b/run_checks_and_format.py
@@ -34,8 +34,8 @@ def run_process(cmd_list):
 
     try:
         p = Popen(cmd_list, stdout=PIPE, stderr=PIPE)
-    except WindowsError:
-        raise WindowsError('Could not call command list: "%s"' % cmd_list)
+    except OSError:
+        raise OSError('Could not call command list: "%s"' % cmd_list)
 
     out, err = p.communicate()
     if PY3:

--- a/tests/test_conformers.py
+++ b/tests/test_conformers.py
@@ -45,7 +45,7 @@ class TestNotConformer(unittest.TestCase):
 
 class TestQLinearGradientConformer(unittest.TestCase):
 
-    css_vars_str = 'qlineargradient($x1, $x2, $y1, $y2, (0 $red, 1 $blue))'
+    css_vars_str = 'qlineargradient($x1, $y1, $x2, $y2, (0 $red, 1 $blue))'
     qss_vars_str = (
         'qlineargradient(x1:$x1, x2:$x2, y1:$y1, y2:$y2'
         'stop: 0 $red, stop: 1 $blue)'
@@ -81,6 +81,14 @@ class TestQLinearGradientConformer(unittest.TestCase):
     qss_rgba_str = (
         'qlineargradient(x1: 0, y1: 0, x2: 0, y2: 0, '
         'stop: 0 rgba(0, 1, 2, 30%), stop: 0.99 rgba(7, 8, 9, 100%))'
+    )
+
+    css_incomplete_coords_str = (
+        'qlineargradient(0, 1, 0, 0, (0 red, 1 blue))'
+    )
+
+    qss_incomplete_coords_str = (
+        'qlineargradient(y1:1, stop:0 red, stop: 1 blue)'
     )
 
     def test_does_not_affect_css_form(self):
@@ -125,3 +133,14 @@ class TestQLinearGradientConformer(unittest.TestCase):
 
         c = QLinearGradientConformer()
         self.assertEqual(c.to_scss(self.qss_rgba_str), self.css_rgba_str)
+
+    def test_incomplete_coords(self):
+        """QLinearGradientConformer qss with not all 4 coordinates given."""
+
+        c = QLinearGradientConformer()
+        self.assertEqual(c.to_scss(self.qss_incomplete_coords_str),
+                         self.css_incomplete_coords_str)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_conformers.py
+++ b/tests/test_conformers.py
@@ -91,6 +91,14 @@ class TestQLinearGradientConformer(unittest.TestCase):
         'qlineargradient(y1:1, stop:0 red, stop: 1 blue)'
     )
 
+    css_float_coords_str = (
+        'qlineargradient(0, 0.75, 0, 0, (0 green, 1 pink))'
+    )
+
+    qss_float_coords_str = (
+        'qlineargradient(y1:0.75, stop:0 green, stop: 1 pink)'
+    )
+
     def test_does_not_affect_css_form(self):
         """QLinearGradientConformer no affect on css qlineargradient func."""
 
@@ -140,6 +148,11 @@ class TestQLinearGradientConformer(unittest.TestCase):
         c = QLinearGradientConformer()
         self.assertEqual(c.to_scss(self.qss_incomplete_coords_str),
                          self.css_incomplete_coords_str)
+
+    def test_float_coords(self):
+        c = QLinearGradientConformer()
+        self.assertEqual(c.to_scss(self.qss_float_coords_str),
+                         self.css_float_coords_str)
 
 
 if __name__ == "__main__":

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -6,27 +6,24 @@
 # Licensed under the terms of the MIT License
 # (See LICENSE.txt for details)
 # -----------------------------------------------------------------------------
-"""Test qtsass conformers."""
+"""Test qtsass custom functions."""
 
 from __future__ import absolute_import
 
 # Standard library imports
-from textwrap import dedent
 import unittest
-
-# Third party imports
-import sass
 
 # Local imports
 from qtsass.api import compile
 
 
 class BaseCompileTest(unittest.TestCase):
-    def compile_scss(self, str):
+    def compile_scss(self, string):
         # NOTE: revise for better future compatibility
-        wstr = '*{{t: {0};}}'.format(str)
+        wstr = '*{{t: {0};}}'.format(string)
         res = compile(wstr)
         return res.replace('* {\n  t: ', '').replace('; }\n', '')
+
 
 class TestRgbaFunc(BaseCompileTest):
     def test_rgba(self):
@@ -34,6 +31,11 @@ class TestRgbaFunc(BaseCompileTest):
             self.compile_scss('rgba(0, 1, 2, 0.3)'),
             'rgba(0, 1, 2, 30%)'
         )
+        self.assertEqual(
+            self.compile_scss('rgba(255, 0, 125, 75%)'),
+            'rgba(255, 0, 125, 75%)'
+        )
+
 
 class TestQLinearGradientFunc(BaseCompileTest):
     def test_color(self):
@@ -49,3 +51,7 @@ class TestQLinearGradientFunc(BaseCompileTest):
             'qlineargradient(x1: 1.0, y1: 2.0, x2: 3.0, y2: 4.0, '
             'stop: 0.0 rgba(255, 0, 0, 100%), stop: 0.2 rgba(5, 6, 7, 80%))'
         )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -31,10 +31,14 @@ class TestRgbaFunc(BaseCompileTest):
             self.compile_scss('rgba(0, 1, 2, 0.3)'),
             'rgba(0, 1, 2, 30%)'
         )
-        self.assertEqual(
-            self.compile_scss('rgba(255, 0, 125, 75%)'),
-            'rgba(255, 0, 125, 75%)'
-        )
+
+    def test_rgba_percentage_alpha(self):
+        result = self.compile_scss('rgba(255, 0, 125, 75%)')
+        self.assertEqual(result, 'rgba(255, 0, 125, 75%)')
+
+    def test_rgba_8bit_int_alpha(self):
+        result = self.compile_scss('rgba(255, 0, 125, 128)')
+        self.assertEqual(result, 'rgba(255, 0, 125, 50%)')
 
 
 class TestQLinearGradientFunc(BaseCompileTest):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -37,8 +37,9 @@ class TestRgbaFunc(BaseCompileTest):
         self.assertEqual(result, 'rgba(255, 0, 125, 75%)')
 
     def test_rgba_8bit_int_alpha(self):
-        result = self.compile_scss('rgba(255, 0, 125, 128)')
-        self.assertEqual(result, 'rgba(255, 0, 125, 50%)')
+        for in_val, out_val in ((0, 0), (128, 50), (255, 100)):
+            result = self.compile_scss('rgba(255, 0, 125, %i)' % in_val)
+            self.assertEqual(result, 'rgba(255, 0, 125, %i%%)' % out_val)
 
 
 class TestQLinearGradientFunc(BaseCompileTest):


### PR DESCRIPTION
Heya! I found some issues that I needed to be fixed for our qss stuff to work after switching from the outdated [python-scss](https://github.com/pistolero/python-scss). Most notably:

- 8d7dd19 as Qt allows to fill in qlineargradient coordinates with 0 values automatically
- c6a89a5 %-values already in `rgba` statements are no longer multiplied by 100 again
- d6b827e now conform with former `compile` calls `compile_filename` also returns the resulting code.

cheers!
ëRiC