### PR TITLE
PR: Add enable_logging to api

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ You can also use watch mode to watch the entire directory for changes.
 qtsass ./static/scss -o ./static/css -w
 ```
 
+Set the Environment Variable QTSASS_DEBUG to 1 or pass the --debug flag to enable logging.
+
+```bash
+qtsass ./static/scss -o ./static/css --debug
+```
+
 ## API methods
 
 ### `compile(string, **kwargs)`
@@ -151,7 +157,7 @@ Examples:
 
 ```bash
 >>> import qtsass
->>> qtsass.compile_filename('dummy.scss', 'dummy.css') 
+>>> qtsass.compile_filename('dummy.scss', 'dummy.css')
 ```
 
 Arguments:
@@ -167,7 +173,7 @@ Examples:
 
 ```bash
 >>> import qtsass
->>> qtsass.compile_filename('dummy.scss', 'dummy.css') 
+>>> qtsass.compile_filename('dummy.scss', 'dummy.css')
 ```
 
 Arguments:
@@ -189,7 +195,28 @@ Arguments:
 - output_dir: Directory to write compiled Qt compliant CSS files to.
 - kwargs: Keyword arguments to pass to sass.compile
 
-### watch(source, destination, compiler=None, recursive=True):
+### `enable_logging(level=None, handler=None)`:
+Enable logging for qtsass.
+
+Sets the qtsass logger's level to:
+    1. the provided logging level
+    2. logging.DEBUG if the QTSASS_DEBUG envvar is a True value
+    3. logging.WARNING
+
+```bash
+>>> import logging
+>>> import qtsass
+>>> handler = logging.StreamHandler()
+>>> formatter = logging.Formatter('%(level)-8s: %(name)s> %(message)s')
+>>> handler.setFormatter(formatter)
+>>> qtsass.enable_logging(level=logging.DEBUG, handler=handler)
+```
+
+Arguments:
+- level: Optional logging level
+- handler: Optional handler to add
+
+### `watch(source, destination, compiler=None, Watcher=None)`:
 Watches a source file or directory, compiling QtSass files when modified.
 
 The compiler function defaults to compile_filename when source is a file
@@ -199,11 +226,10 @@ Arguments:
 - source: Path to source QtSass file or directory.
 - destination: Path to output css file or directory.
 - compiler: Compile function (optional)
-- recursive: If True, watch subdirectories (default: True).
+- Watcher: Defaults to qtsass.watchers.Watcher (optional)
 
-Returns: 
-- watchdog.Observer
-
+Returns:
+- qtsass.watchers.Watcher instance
 
 ## Contributing
 

--- a/qtsass/__init__.py
+++ b/qtsass/__init__.py
@@ -21,11 +21,25 @@ those variations.
 
 from __future__ import absolute_import
 
+# Standard library imports
+import logging
+
 # Local imports
-from qtsass.api import compile, compile_dirname, compile_filename, watch
+from qtsass.api import (
+    compile,
+    compile_dirname,
+    compile_filename,
+    watch,
+    enable_logging,
+)
 
 
 # yapf: enable
+
+
+# Setup Logging
+logging.getLogger(__name__).addHandler(logging.NullHandler())
+enable_logging()
 
 # Constants
 VERSION_INFO = (0, 1, 2, 'dev0')

--- a/qtsass/__init__.py
+++ b/qtsass/__init__.py
@@ -29,13 +29,12 @@ from qtsass.api import (
     compile,
     compile_dirname,
     compile_filename,
-    watch,
     enable_logging,
+    watch,
 )
 
 
 # yapf: enable
-
 
 # Setup Logging
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/qtsass/cli.py
+++ b/qtsass/cli.py
@@ -25,9 +25,10 @@ from qtsass.api import (
     compile,
     compile_dirname,
     compile_filename,
-    watch,
     enable_logging,
+    watch,
 )
+
 
 # yapf: enable
 
@@ -68,7 +69,6 @@ def create_parser():
 
 def main():
     """CLI entry point."""
-
     args = create_parser().parse_args()
 
     # Setup CLI logging

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ blank_line_before_nested_class_or_def = false
 from_first = true
 import_heading_stdlib = Standard library imports
 import_heading_firstparty = Local imports
+import_heading_localfolder = Local imports
 import_heading_thirdparty = Third party imports
 indent = '    '
 known_first_party = qtsass

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,3 +47,5 @@ line_length = 79
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 lines_after_imports = 2
 skip = venv
+multi_line_output = 3
+include_trailing_comma = true

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import
 
 # Standard library imports
 from os.path import exists
+import logging
 
 # Third party imports
 import pytest
@@ -54,6 +55,14 @@ QWidget {
     border: custom_border();
 }
 """
+
+
+def setup_module():
+    qtsass.enable_logging(level=logging.DEBUG)
+
+
+def teardown_module():
+    qtsass.enable_logging(level=logging.WARNING)
 
 
 def test_compile_strings():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,6 +21,7 @@ import sass
 # Local imports
 import qtsass
 
+# Local imports
 from . import EXAMPLES_DIR, PROJECT_DIR, example
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,7 @@ from os.path import basename, exists
 from subprocess import PIPE, Popen
 import time
 
-#Local imports
+# Local imports
 from . import PROJECT_DIR, await_condition, example, touch
 
 

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -25,6 +25,7 @@ from qtsass import compile_filename
 from qtsass.watchers import PollingWatcher, QtWatcher
 from qtsass.watchers.api import retry
 
+# Local imports
 from . import EXAMPLES_DIR, await_condition, example, touch
 
 


### PR DESCRIPTION
Closes #46

- Add the enable_logging method
- Document enable_logging method
- Document --debug cli flag
- Document QTSASS_DEBUG env var

By default the cli logging level is set to INFO.