### PR TITLE
PR: Constraint libsass to 0.21.0 and update .authors.yml file

### DIFF
--- a/.authors.yml
+++ b/.authors.yml
@@ -45,8 +45,14 @@
   num_commits: 22
   first_commit: 2015-08-16 05:22:05
   github: yann-lty
-- name: Daniel Althviz
+- name: Daniel Althviz Moré
   email: d.althviz10@uniandes.edu.co
   aliases:
   - dalthviz
+  - Daniel Althviz
   github: dalthviz
+- name: Sebastian Weigand
+  email: s.weigand.phy@gmail.com
+  aliases:
+  - s-weigand
+  github: s-weigand

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,5 @@
 codecov
+flaky
 isort==4.3.15
 pycodestyle==2.5.0
 pydocstyle==3.0.0

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ),
     install_requires=[
-        'libsass',
+        'libsass<=0.21.0',
     ],
     keywords='qt sass qtsass scss css qss stylesheets',
 )

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -18,6 +18,7 @@ import sys
 import time
 
 # Third party imports
+from flaky import flaky
 import pytest
 
 # Local imports
@@ -42,6 +43,7 @@ class CallCounter(object):
 @pytest.mark.parametrize(
     'Watcher', (PollingWatcher, QtWatcher),
 )
+@flaky(max_runs=3)
 def test_watchers(Watcher, tmpdir):
     """Stress test Watcher implementations"""
 


### PR DESCRIPTION
- [x] Add constraint for `libsass<=0.21.0` since seems like a new version [will drop support for Python 2.7](https://github.com/sass/libsass-python/commit/d333e3c419f48f4b2d96528cb4c83db1f02adaec) (which is currently supported here).
- [x] Update .authors.yml file to include missing entry.