### PR TITLE
PR: Made `compile_filename` file output optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,37 +148,25 @@ Arguments:
 Returns:
 - Qt compliant CSS string
 
-### `compile_filename(input_file, dest_file, **kwargs)`:
+### `compile_filename(input_file, output_file=None, **kwargs)`:
 
-Compile and save QtSASS file as Qt compliant CSS.
-
-Examples:
-
-```bash
->>> import qtsass
->>> qtsass.compile_filename('dummy.scss', 'dummy.css')
-```
-
-Arguments:
-- input_file: Path to QtSass file.
-- dest_file: Path to destination Qt compliant CSS file.
-- kwargs: Keyword arguments to pass to sass.compile
-
-### `compile_filename(input_file, output_file, **kwargs)`:
-
-Compile and save QtSASS file as Qt compliant CSS.
+Compile and return a QtSASS file as Qt compliant CSS. Optionally save to a file.
 
 Examples:
 
 ```bash
 >>> import qtsass
->>> qtsass.compile_filename('dummy.scss', 'dummy.css')
+>>> qtsass.compile_filename("dummy.scss", "dummy.css")
+>>> css = qtsass.compile_filename("dummy.scss")
 ```
 
 Arguments:
 - input_file: Path to QtSass file.
 - output_file: Path to write Qt compliant CSS.
 - kwargs: Keyword arguments to pass to sass.compile
+
+Returns:
+- Qt compliant CSS string
 
 ### `compile_dirname(input_dir, output_dir, **kwargs)`:
 

--- a/qtsass/api.py
+++ b/qtsass/api.py
@@ -113,7 +113,8 @@ def compile(string, **kwargs):
 
 
 def compile_filename(input_file, output_file=None, **kwargs):
-    """Compile and return a QtSASS file as Qt compliant CSS. Optionally save to a file.
+    """Compile and return a QtSASS file as Qt compliant CSS.
+    Optionally save to a file.
 
     .. code-block:: python
 
@@ -142,7 +143,8 @@ def compile_filename(input_file, output_file=None, **kwargs):
 
         with open(output_file, 'w') as css_file:
             css_file.write(css)
-            _log.info('Created CSS file {}'.format(os.path.normpath(output_file)))
+            _log.info('Created CSS file {}'.format(
+                os.path.normpath(output_file)))
 
     return css
 

--- a/qtsass/api.py
+++ b/qtsass/api.py
@@ -112,16 +112,17 @@ def compile(string, **kwargs):
         raise
 
 
-def compile_filename(input_file, output_file, **kwargs):
-    """Compile and save QtSASS file as CSS.
+def compile_filename(input_file, output_file=None, **kwargs):
+    """Compile and return a QtSASS file as Qt compliant CSS. Optionally save to a file.
 
     .. code-block:: python
 
         >>> import qtsass
         >>> qtsass.compile_filename("dummy.scss", "dummy.css")
+        >>> css = qtsass.compile_filename("dummy.scss")
 
     :param input_file: Path to QtSass file.
-    :param output_file: Path to write Qt compliant CSS.
+    :param output_file: Optional path to write Qt compliant CSS.
     :param kwargs: Keyword arguments to pass to sass.compile
     :returns: CSS string
     """
@@ -134,13 +135,14 @@ def compile_filename(input_file, output_file, **kwargs):
     _log.info('Compiling {}...'.format(os.path.normpath(input_file)))
     css = compile(string, **kwargs)
 
-    output_root = os.path.abspath(os.path.dirname(output_file))
-    if not os.path.isdir(output_root):
-        os.makedirs(output_root)
+    if output_file is not None:
+        output_root = os.path.abspath(os.path.dirname(output_file))
+        if not os.path.isdir(output_root):
+            os.makedirs(output_root)
 
-    with open(output_file, 'w') as css_file:
-        css_file.write(css)
-        _log.info('Created CSS file {}'.format(os.path.normpath(output_file)))
+        with open(output_file, 'w') as css_file:
+            css_file.write(css)
+            _log.info('Created CSS file {}'.format(os.path.normpath(output_file)))
 
     return css
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -138,12 +138,26 @@ def test_compile_filename(tmpdir):
     assert exists(output.strpath)
 
 
+def test_compile_filename_no_save():
+    """compile_filename simple."""
+
+    qss = qtsass.compile_filename(example('dummy.scss'))
+    assert isinstance(qss, str)
+
+
 def test_compile_filename_imports(tmpdir):
     """compile_filename with imports."""
 
     output = tmpdir.join('dark.css')
     qtsass.compile_filename(example('complex', 'dark.scss'), output.strpath)
     assert exists(output.strpath)
+
+
+def test_compile_filename_imports_no_save():
+    """compile_filename with imports."""
+
+    qss = qtsass.compile_filename(example('complex', 'dark.scss'))
+    assert isinstance(qss, str)
 
 
 def test_compile_dirname(tmpdir):


### PR DESCRIPTION
There are uses cases to get the QSS compiled string from a file without having to save it to a file.
This makes the `output_file` in `compile_filename` optional. If undefined it will not save the output to a file and will just return it. 
The documentation for `compile_filename` in the readme was duplicated so I removed the duplication.