### PR TITLE
PR: Replace `@flaky` decorator with pytest marker

### DIFF
--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -18,7 +18,6 @@ import sys
 import time
 
 # Third party imports
-from flaky import flaky
 import pytest
 
 # Local imports
@@ -43,7 +42,7 @@ class CallCounter(object):
 @pytest.mark.parametrize(
     'Watcher', (PollingWatcher, QtWatcher),
 )
-@flaky(max_runs=3)
+@pytest.mark.flaky(max_runs=3)
 def test_watchers(Watcher, tmpdir):
     """Stress test Watcher implementations"""
 


### PR DESCRIPTION
Use the `@pytest.mark.flaky` marker in place of the `@flaky.flaky` decorator, to modernize the code and improve compatibility with other plugins providing the feature such as `pytest-rerunfailures`.