### PR TITLE
PR: Update workflow actions, add `.spyproject` to `.gitignore` and other CI updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
         PYTHON_VERSION: ['3.7', '3.10']
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
            activate-environment: test
            python-version: ${{ matrix.PYTHON_VERSION }} 
@@ -70,9 +70,9 @@ jobs:
         PYTHON_VERSION: ['3.8', '3.9']
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
            activate-environment: test
            python-version: ${{ matrix.PYTHON_VERSION }} 
@@ -111,9 +111,9 @@ jobs:
         PYTHON_VERSION: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
            activate-environment: test
            python-version: ${{ matrix.PYTHON_VERSION }} 
@@ -152,9 +152,9 @@ jobs:
         PYTHON_VERSION: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
            activate-environment: test
            python-version: ${{ matrix.PYTHON_VERSION }} 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
     strategy:
       fail-fast: false 
       matrix:
-        PYTHON_VERSION: ['3.7', '3.8', '3.9', '3.10']
+        PYTHON_VERSION: ['3.8', '3.9', '3.10']
     steps:
       - name: Checkout branch
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         PYTHON_VERSION: ['3.7', '3.10']
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Conda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -71,7 +71,7 @@ jobs:
         PYTHON_VERSION: ['3.8', '3.9']
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Conda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -113,7 +113,7 @@ jobs:
         PYTHON_VERSION: ['3.8', '3.9', '3.10']
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Conda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -155,7 +155,7 @@ jobs:
         PYTHON_VERSION: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Conda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -188,11 +188,11 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     needs: [windows, macos, linux]
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel setuptools
@@ -201,7 +201,7 @@ jobs:
           python setup.py sdist bdist_wheel
 
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@v1.5.1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
            activate-environment: test
-           python-version: ${{ matrix.PYTHON_VERSION }} 
+           python-version: ${{ matrix.PYTHON_VERSION }}
+           channels: conda-forge
       - name: Install Dependencies
         shell: bash -l {0}
         run: pip install -r requirements/install.txt
@@ -75,7 +76,8 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
            activate-environment: test
-           python-version: ${{ matrix.PYTHON_VERSION }} 
+           python-version: ${{ matrix.PYTHON_VERSION }}
+           channels: conda-forge
       - name: Install Dependencies
         shell: bash -l {0}
         run: pip install -r requirements/install.txt
@@ -116,7 +118,8 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
            activate-environment: test
-           python-version: ${{ matrix.PYTHON_VERSION }} 
+           python-version: ${{ matrix.PYTHON_VERSION }}
+           channels: conda-forge
       - name: Install Dependencies
         shell: bash -l {0}
         run: pip install -r requirements/install.txt
@@ -157,7 +160,8 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
            activate-environment: test
-           python-version: ${{ matrix.PYTHON_VERSION }} 
+           python-version: ${{ matrix.PYTHON_VERSION }}
+           channels: conda-forge
       - name: Install Dependencies
         shell: bash -l {0}
         run: pip install -r requirements/install.txt

--- a/.gitignore
+++ b/.gitignore
@@ -275,3 +275,7 @@ activate.xsh
 
 # Loghub
 CHANGELOG.temp
+
+# Spyder
+.spyproject/
+


### PR DESCRIPTION
Update CI workflow definition:

* Update actions versions: `actions/checkout` to v4, `conda-incubator/setup-minicoda` to v3 and `pypa/gh-action-pypi-publish` to release/v1
* Add conda-forge channel to `setup-miniconda` action
* Remove Python 3.7 from macOS matrix since no arm macOS package is available for that Python version
* Update `deploy` job to use Python 3.10

Other changes:

* Update `.gitignore` to have `.spyproject`